### PR TITLE
Update SNMP username for bionic

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -109,7 +109,7 @@ class snmp::params {
       $sysconfig            = '/etc/default/snmpd'
       $var_net_snmp         = '/var/lib/snmp'
       $varnetsnmp_perms     = '0755'
-      if $lsbdistcodename == "bionic" {
+      if versioncmp($::lsbdistrelease, '16.04') > 0 {
         $varnetsnmp_owner     = 'Debian-snmp'
       } else {
         $varnetsnmp_owner     = 'snmp'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -109,7 +109,11 @@ class snmp::params {
       $sysconfig            = '/etc/default/snmpd'
       $var_net_snmp         = '/var/lib/snmp'
       $varnetsnmp_perms     = '0755'
-      $varnetsnmp_owner     = 'snmp'
+      if $lsbdistcodename == "bionic" {
+        $varnetsnmp_owner     = 'Debian-snmp'
+      } else {
+        $varnetsnmp_owner     = 'snmp'
+      }
       $varnetsnmp_group     = 'snmp'
 
       $client_package_name  = 'snmp'


### PR DESCRIPTION
The new netmon appears to be the first bionic host trying to use this module:
```
ogarraux@dev73-uswest1adevc:~/sysgit/puppet (u/ogarraux/NETENG-2421-bionic-netmon1-1) $ mco find -C "snmp" -F lsbdistcodename=bionic
netmon1-uswest2aprod.uswest2-prod.yelpcorp.com
```
Bionic seems to use a different username for SNMP - "Debian-snmp" instead of just snmp.

The upstream module for this appears to be several major versions ahead of us, we haven't updated this from the upstream code in 7(!) years.  It feels like trying to do that would end up being a huge yak shave.

pbers seems wildly broken on this even before my change.  My change doesn't add any additional failures though.

This fixes the wwho for the new netmon.

Hosts using this class: https://fluffy.yelpcorp.com/i/SxJ3qqZTpmltC8mqrWf1zxXg58L5ZRTV.html
It appears to be a no-op on xenial netsrvs: https://fluffy.yelpcorp.com/i/KH6zZ3MTqSWf4Xj1VrPgBrJJmhxHvp0C.html

And on an AWS host that's using this class:
https://fluffy.yelpcorp.com/i/g6rtw1G4J784h63qc0nKDcM3bPkr7Twf.html